### PR TITLE
Close the temp file before renaming otherwise it fails on windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,13 +180,14 @@ func downloadMessage(svc *gmail.Service, id string, user string, outputPath stri
 		return err
 	}
 
-	path := filepath.Join(outputPath, id)
-	err = os.Rename(f.Name(), path)
+	tmpName := f.Name()
+	err = f.Close()
 	if err != nil {
 		return err
 	}
 
-	err = f.Close()
+	path := filepath.Join(outputPath, id)
+	err = os.Rename(tmpName, path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Running the script on windows fails, as rename isn't possible while the file isn't closed.

This fixes that, I hope it doesn't break a posix side-effect?